### PR TITLE
Blog に user を ownerId として紐付ける

### DIFF
--- a/apps/api/prisma/migrations/20240824111114_add_relation_user_and_blog/migration.sql
+++ b/apps/api/prisma/migrations/20240824111114_add_relation_user_and_blog/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "blogs" ADD COLUMN     "owener_id" TEXT NOT NULL,
+ALTER COLUMN "updated_at" DROP DEFAULT;
+
+-- AddForeignKey
+ALTER TABLE "blogs" ADD CONSTRAINT "blogs_owener_id_fkey" FOREIGN KEY ("owener_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/api/prisma/migrations/20240824124658_add_session_table/migration.sql
+++ b/apps/api/prisma/migrations/20240824124658_add_session_table/migration.sql
@@ -1,0 +1,20 @@
+/*
+  Warnings:
+
+  - You are about to drop the `session` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE "session";
+
+-- CreateTable
+CREATE TABLE "sessions" (
+    "sid" TEXT NOT NULL,
+    "sess" JSONB NOT NULL,
+    "expire" TIMESTAMPTZ(6) NOT NULL,
+
+    CONSTRAINT "sessions_pkey" PRIMARY KEY ("sid")
+);
+
+-- CreateIndex
+CREATE INDEX "IDX_sessions_expire" ON "sessions"("expire");

--- a/apps/api/prisma/migrations/20240824130338_fix_typo_about_owner/migration.sql
+++ b/apps/api/prisma/migrations/20240824130338_fix_typo_about_owner/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `owener_id` on the `blogs` table. All the data in the column will be lost.
+  - Added the required column `owner_id` to the `blogs` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "blogs" DROP CONSTRAINT "blogs_owener_id_fkey";
+
+-- AlterTable
+ALTER TABLE "blogs" DROP COLUMN "owener_id",
+ADD COLUMN     "owner_id" TEXT NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "blogs" ADD CONSTRAINT "blogs_owner_id_fkey" FOREIGN KEY ("owner_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -38,6 +38,19 @@ model User {
   email     String   @unique
   name      String
   createdAt DateTime @default(now()) @map("created_at")
+
+  blogs Blog[]
+
+  @@map("users")
+}
+
+model Session {
+  sid    String   @id
+  sess   Json
+  expire DateTime @db.Timestamptz(6)
+
+  @@index([expire], name: "IDX_sessions_expire")
+  @@map("sessions")
 }
 
 model Blog {
@@ -47,7 +60,11 @@ model Blog {
   /// @zod.string.min(3, { message: "3字以上で入力してください" })
   subDomain String @unique @map("sub_domain")
 
-  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt DateTime @default(now()) @map("updated_at") @db.Timestamptz()
+  owenerId String @map("owener_id")
+  owner    User   @relation(fields: [owenerId], references: [id])
 
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz()
+
+  @@map("blogs")
 }

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -60,8 +60,8 @@ model Blog {
   /// @zod.string.min(3, { message: "3字以上で入力してください" })
   subDomain String @unique @map("sub_domain")
 
-  owenerId String @map("owener_id")
-  owner    User   @relation(fields: [owenerId], references: [id])
+  ownerId String @map("owner_id")
+  owner   User   @relation(fields: [ownerId], references: [id])
 
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz()
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz()

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -38,8 +38,6 @@ model User {
   email     String   @unique
   name      String
   createdAt DateTime @default(now()) @map("created_at")
-
-  @@map("users")
 }
 
 model Blog {
@@ -52,5 +50,4 @@ model Blog {
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz()
   updatedAt DateTime @default(now()) @map("updated_at") @db.Timestamptz()
 
-  @@map("blogs")
 }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -30,6 +30,7 @@ app.use(
       maxAge: 24 * 60 * 60 * 1000, // クッキーの有効期限(msec)
     },
     store: new PgSession({
+      tableName: 'sessions',
       pool: new Pool({
         user: url.username,
         password: url.password,

--- a/apps/web/src/components/WrapperWithMenu/index.tsx
+++ b/apps/web/src/components/WrapperWithMenu/index.tsx
@@ -1,1 +1,1 @@
-export { WrapperWithMenu } from "./WrapperWithMenu";
+export { WrapperWithMenu } from './WrapperWithMenu';

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -7,12 +7,6 @@
       "~/*": ["src/*"]
     }
   },
-  "include": [
-    "next-env.d.ts",
-    "next.config.js",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts"
-  ],
+  "include": ["next-env.d.ts", "next.config.js", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/biome.json
+++ b/biome.json
@@ -17,7 +17,15 @@
     }
   },
   "files": {
-    "ignore": ["node_modules/", "dist/", "build/", "**/*.test.ts", "**/*.spec.ts", "**/.next/**", "**/next.config.js"]
+    "ignore": [
+      "node_modules/",
+      "dist/",
+      "build/",
+      "**/*.test.ts",
+      "**/*.spec.ts",
+      "**/.next/**",
+      "**/next.config.js"
+    ]
   },
   "linter": {
     "enabled": true,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "with-docker",
   "version": "0.0.0",
   "private": true,
-  "workspaces": ["apps/*", "packages/*"],
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
   "scripts": {
     "build": "turbo run build",
     "clean": "turbo run clean",

--- a/packages/types/src/inputTypeSchemas/BlogScalarFieldEnumSchema.ts
+++ b/packages/types/src/inputTypeSchemas/BlogScalarFieldEnumSchema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
 
-export const BlogScalarFieldEnumSchema = z.enum(['id', 'name', 'subDomain', 'owenerId', 'createdAt', 'updatedAt']);
+export const BlogScalarFieldEnumSchema = z.enum(['id', 'name', 'subDomain', 'ownerId', 'createdAt', 'updatedAt']);
 
 export default BlogScalarFieldEnumSchema;

--- a/packages/types/src/inputTypeSchemas/BlogScalarFieldEnumSchema.ts
+++ b/packages/types/src/inputTypeSchemas/BlogScalarFieldEnumSchema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
 
-export const BlogScalarFieldEnumSchema = z.enum(['id', 'name', 'subDomain', 'createdAt', 'updatedAt']);
+export const BlogScalarFieldEnumSchema = z.enum(['id', 'name', 'subDomain', 'owenerId', 'createdAt', 'updatedAt']);
 
 export default BlogScalarFieldEnumSchema;

--- a/packages/types/src/inputTypeSchemas/InputJsonValueSchema.ts
+++ b/packages/types/src/inputTypeSchemas/InputJsonValueSchema.ts
@@ -1,0 +1,17 @@
+import type { Prisma } from '@prisma/client';
+import { z } from 'zod';
+
+export const InputJsonValueSchema: z.ZodType<Prisma.InputJsonValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.object({ toJSON: z.function(z.tuple([]), z.any()) }),
+    z.record(z.lazy(() => z.union([InputJsonValueSchema, z.literal(null)]))),
+    z.array(z.lazy(() => z.union([InputJsonValueSchema, z.literal(null)]))),
+  ]),
+);
+
+export type InputJsonValueType = z.infer<typeof InputJsonValueSchema>;
+
+export default InputJsonValueSchema;

--- a/packages/types/src/inputTypeSchemas/JsonNullValueFilterSchema.ts
+++ b/packages/types/src/inputTypeSchemas/JsonNullValueFilterSchema.ts
@@ -1,0 +1,14 @@
+import { Prisma } from '@prisma/client';
+import { z } from 'zod';
+
+export const JsonNullValueFilterSchema = z
+  .enum(['DbNull', 'JsonNull', 'AnyNull'])
+  .transform(value =>
+    value === 'JsonNull'
+      ? Prisma.JsonNull
+      : value === 'DbNull'
+        ? Prisma.JsonNull
+        : value === 'AnyNull'
+          ? Prisma.AnyNull
+          : value,
+  );

--- a/packages/types/src/inputTypeSchemas/JsonNullValueInputSchema.ts
+++ b/packages/types/src/inputTypeSchemas/JsonNullValueInputSchema.ts
@@ -1,0 +1,6 @@
+import { Prisma } from '@prisma/client';
+import { z } from 'zod';
+
+export const JsonNullValueInputSchema = z
+  .enum(['JsonNull'])
+  .transform(value => (value === 'JsonNull' ? Prisma.JsonNull : value));

--- a/packages/types/src/inputTypeSchemas/JsonValueSchema.ts
+++ b/packages/types/src/inputTypeSchemas/JsonValueSchema.ts
@@ -1,0 +1,17 @@
+import type { Prisma } from '@prisma/client';
+import { z } from 'zod';
+
+export const JsonValueSchema: z.ZodType<Prisma.JsonValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.literal(null),
+    z.record(z.lazy(() => JsonValueSchema.optional())),
+    z.array(z.lazy(() => JsonValueSchema)),
+  ]),
+);
+
+export type JsonValueType = z.infer<typeof JsonValueSchema>;
+
+export default JsonValueSchema;

--- a/packages/types/src/inputTypeSchemas/SessionScalarFieldEnumSchema.ts
+++ b/packages/types/src/inputTypeSchemas/SessionScalarFieldEnumSchema.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+
+export const SessionScalarFieldEnumSchema = z.enum(['sid', 'sess', 'expire']);
+
+export default SessionScalarFieldEnumSchema;

--- a/packages/types/src/inputTypeSchemas/index.ts
+++ b/packages/types/src/inputTypeSchemas/index.ts
@@ -1,6 +1,11 @@
 export { TransactionIsolationLevelSchema } from './TransactionIsolationLevelSchema';
 export { UserScalarFieldEnumSchema } from './UserScalarFieldEnumSchema';
 export { RelationLoadStrategySchema } from './RelationLoadStrategySchema';
+export { SessionScalarFieldEnumSchema } from './SessionScalarFieldEnumSchema';
 export { BlogScalarFieldEnumSchema } from './BlogScalarFieldEnumSchema';
 export { SortOrderSchema } from './SortOrderSchema';
+export { JsonNullValueInputSchema } from './JsonNullValueInputSchema';
 export { QueryModeSchema } from './QueryModeSchema';
+export { JsonNullValueFilterSchema } from './JsonNullValueFilterSchema';
+export { InputJsonValueSchema } from './InputJsonValueSchema';
+export { JsonValueSchema } from './JsonValueSchema';

--- a/packages/types/src/modelSchema/BlogSchema.ts
+++ b/packages/types/src/modelSchema/BlogSchema.ts
@@ -8,7 +8,7 @@ export const BlogSchema = z.object({
   id: z.string(),
   name: z.string().max(255, { message: '255字未満で入力してください' }),
   subDomain: z.string().min(3, { message: '3字以上で入力してください' }),
-  owenerId: z.string(),
+  ownerId: z.string(),
   createdAt: z.coerce.date(),
   updatedAt: z.coerce.date(),
 });

--- a/packages/types/src/modelSchema/BlogSchema.ts
+++ b/packages/types/src/modelSchema/BlogSchema.ts
@@ -8,6 +8,7 @@ export const BlogSchema = z.object({
   id: z.string(),
   name: z.string().max(255, { message: '255字未満で入力してください' }),
   subDomain: z.string().min(3, { message: '3字以上で入力してください' }),
+  owenerId: z.string(),
   createdAt: z.coerce.date(),
   updatedAt: z.coerce.date(),
 });

--- a/packages/types/src/modelSchema/SessionSchema.ts
+++ b/packages/types/src/modelSchema/SessionSchema.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+import { JsonValueSchema } from '../inputTypeSchemas/JsonValueSchema';
+
+/////////////////////////////////////////
+// SESSION SCHEMA
+/////////////////////////////////////////
+
+export const SessionSchema = z.object({
+  sid: z.string(),
+  sess: JsonValueSchema,
+  expire: z.coerce.date(),
+});
+
+export type Session = z.infer<typeof SessionSchema>;
+
+export default SessionSchema;

--- a/packages/types/src/modelSchema/index.ts
+++ b/packages/types/src/modelSchema/index.ts
@@ -1,2 +1,3 @@
 export * from './UserSchema';
+export * from './SessionSchema';
 export * from './BlogSchema';

--- a/turbo.json
+++ b/turbo.json
@@ -23,6 +23,10 @@
     },
     "clean": {
       "cache": false
+    },
+    "schema:gen": {
+      "dependsOn": ["^schema:gen"],
+      "env": ["DATABASE_URL"]
     }
   }
 }


### PR DESCRIPTION
## 対象の Issue

https://github.com/users/itizawa/projects/5/views/1?pane=issue&itemId=75182449 ために必要な対応


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `owner_id` field in blog entries linking them to users, enhancing ownership management.
	- Created a new `sessions` table for improved session management with structured session data.
	- Added JSON validation schemas for enhanced data integrity and type safety, including new schemas for JSON values and session data.
  
- **Bug Fixes**
	- Corrected the spelling of `owner_id` by dropping the previously incorrect `owener_id` field.

- **Documentation**
	- Updated exports in the type schemas to include new JSON and session-related schemas, improving usability.

- **Chores**
	- Refactored configuration files for improved readability and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->