### PR TITLE
ダッシュボードで自身が作成したブログを一覧で表示する

### DIFF
--- a/apps/web/src/actions/blog.ts
+++ b/apps/web/src/actions/blog.ts
@@ -1,6 +1,30 @@
 'use server';
 
+import type { Blog } from '@repo/types';
 import { trpcClient } from '~/libs/trpcClient/trpcClient';
+
+const transferToObject = (
+  blog: Omit<Blog, 'createdAt' | 'updatedAt'> & {
+    createdAt: string;
+    updatedAt: string;
+  },
+) => {
+  return {
+    ...blog,
+    createdAt: new Date(blog.createdAt),
+    updatedAt: new Date(blog.updatedAt),
+  };
+};
+
+export const getBlogsByOwnerId = async ({ ownerId }: { ownerId: string }) => {
+  const { blogs } = await trpcClient.blog.getBlogsByOwnerId.query({
+    ownerId,
+  });
+
+  return {
+    blogs: blogs.map(transferToObject),
+  };
+};
 
 export const getBlogsBySubDomain = async ({ subDomain }: { subDomain: string }) => {
   return await trpcClient.blog.getBlogsBySubDomain.query({

--- a/apps/web/src/app/dashboards/blogs/page.tsx
+++ b/apps/web/src/app/dashboards/blogs/page.tsx
@@ -1,0 +1,22 @@
+import { Box, Stack, Typography } from '@mui/material';
+import { getCurrentUser } from '~/actions/user';
+import { BlogCard } from '~/components/models/blog/BlogCard';
+import { getBlogsByOwnerId } from '../../../actions/blog';
+
+export default async function Page() {
+  const { currentUser } = await getCurrentUser();
+  if (!currentUser) return null;
+
+  const { blogs } = await getBlogsByOwnerId({ ownerId: currentUser?.id });
+
+  return (
+    <Stack maxWidth={600} mx='auto' pt={4} gap={3}>
+      <Typography variant='h5'>ブログ一覧</Typography>
+      {blogs.map(blog => (
+        <Box key={blog.id} width='100%'>
+          <BlogCard blog={blog} />
+        </Box>
+      ))}
+    </Stack>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,9 +1,26 @@
-'use client';
+import { Link, Stack, Typography } from '@mui/material';
+import urlJoin from 'url-join';
+import { getCurrentUser } from '~/actions/user';
 
-export default function Page() {
+export default async function Page() {
+  const { currentUser } = await getCurrentUser();
+
   return (
-    <div>
-      <h1>Web</h1>
-    </div>
+    <Stack maxWidth={600} mx='auto' pt={4} gap={3}>
+      <Typography variant='h5'>Welcome to Wisblog !</Typography>
+      {currentUser ? (
+        <Link href={'/dashboards/blogs'} color='info' sx={{ textDecoration: 'none' }}>
+          <Typography variant='h5'>ダッシュボードへ</Typography>
+        </Link>
+      ) : (
+        <Link
+          href={urlJoin(process.env.NEXT_PUBLIC_API_HOST || 'http://localhost:8080', '/users/auth/google')}
+          color='info'
+          sx={{ textDecoration: 'none' }}
+        >
+          <Typography variant='h5'>ログイン</Typography>
+        </Link>
+      )}
+    </Stack>
   );
 }

--- a/apps/web/src/components/layout/Navbar/Navbar.tsx
+++ b/apps/web/src/components/layout/Navbar/Navbar.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { Logout } from '@mui/icons-material';
+import { Dashboard, Logout } from '@mui/icons-material';
 import { Avatar, Button, Container, IconButton, Stack, Toolbar, Typography, useTheme } from '@mui/material';
 import type { User } from '@repo/types';
 import Link from 'next/link';
 import type { FC } from 'react';
 import urlJoin from 'url-join';
 import { WrapperWithMenu } from '~/components/uiParts/WrapperWithMenu';
+import { generateMainUrl } from '~/utils/generateMainUrl';
 
 type Props = {
   currentUser: User | null;
@@ -40,6 +41,14 @@ export const Navbar: FC<Props> = ({ currentUser }) => {
           {currentUser ? (
             <WrapperWithMenu
               menuItems={[
+                {
+                  key: 'dashboards',
+                  onClick: () => {
+                    window.location.href = urlJoin(generateMainUrl(), 'dashboards/blogs');
+                  },
+                  text: 'ダッシュボード',
+                  icon: <Dashboard fontSize='small' sx={{ mr: 1 }} />,
+                },
                 {
                   key: 'logout',
                   onClick: () => {

--- a/apps/web/src/components/models/blog/BlogCard/BlogCard.tsx
+++ b/apps/web/src/components/models/blog/BlogCard/BlogCard.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { Card, CardContent, Link, Typography } from '@mui/material';
+import type { Blog } from '@repo/types';
+import { format } from 'date-fns';
+import type { FC } from 'react';
+import { generateSubDomainUrl } from '~/utils/generateSubDomainUrl';
+
+type Props = {
+  blog: Blog;
+};
+export const BlogCard: FC<Props> = ({ blog }) => {
+  return (
+    <Card>
+      <CardContent>
+        <Link href={generateSubDomainUrl(blog.subDomain)} color='info' sx={{ textDecoration: 'none' }}>
+          <Typography variant='h5' component='div'>
+            {blog.name}
+          </Typography>
+        </Link>
+        <Typography variant='body2' component='h6'>
+          作成日：{format(blog.createdAt, 'yyyy-MM-dd HH:mm')}
+        </Typography>
+      </CardContent>
+    </Card>
+  );
+};

--- a/apps/web/src/components/models/blog/BlogCard/index.ts
+++ b/apps/web/src/components/models/blog/BlogCard/index.ts
@@ -1,0 +1,1 @@
+export { BlogCard } from './BlogCard';

--- a/apps/web/src/utils/generateMainUrl/generateMainUrl.ts
+++ b/apps/web/src/utils/generateMainUrl/generateMainUrl.ts
@@ -1,0 +1,8 @@
+export const generateMainUrl = () => {
+  const currentHost = window.location.hostname;
+
+  if (currentHost.includes('localhost')) {
+    return 'http://localhost:3000';
+  }
+  return `https://${currentHost}`;
+};

--- a/apps/web/src/utils/generateMainUrl/index.ts
+++ b/apps/web/src/utils/generateMainUrl/index.ts
@@ -1,0 +1,1 @@
+export { generateMainUrl } from './generateMainUrl';

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "migrate:dev:reset": "turbo run migrate:dev:reset",
     "migrate:gen": "turbo run migrate:gen --"
   },
-  "dependencies": {},
+  "dependencies": {
+    "date-fns": "^3.6.0"
+  },
   "devDependencies": {
     "@biomejs/biome": "^1.8.3",
     "turbo": "^2.1.1"

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -38,6 +38,9 @@ app.use(
     cookie: {
       domain: process.env.MAIN_DOMAIN,
       maxAge: 24 * 60 * 60 * 1000, // クッキーの有効期限(msec)
+      path: '/',
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
     },
     store: new PgSession({
       tableName: 'sessions',

--- a/packages/api/src/controllers/blogRouter.ts
+++ b/packages/api/src/controllers/blogRouter.ts
@@ -16,6 +16,14 @@ export const blogRouter = router({
         ownerId: ctx.user.id,
       });
     }),
+  getBlogsByOwnerId: publicProcedure.input(BlogSchema.pick({ ownerId: true })).query(async ({ input }) => {
+    const blogs = await prismaClient.blog.findMany({
+      where: { ownerId: input.ownerId },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return { blogs };
+  }),
   getBlogsBySubDomain: publicProcedure.input(BlogSchema.pick({ subDomain: true })).query(async ({ input }) => {
     return await prismaClient.blog.findFirst({
       where: { subDomain: input.subDomain },

--- a/packages/api/src/controllers/passport.ts
+++ b/packages/api/src/controllers/passport.ts
@@ -100,7 +100,19 @@ passportRoutes.get(
       if (err) {
         return next();
       }
-      return res.redirect(FRONT_URL);
+
+      // ユーザーがアクセスしていたホスト名を取得
+      const host = req.headers.host || '';
+      // ローカルホストかどうかを確認
+      if (host.includes('localhost')) {
+        // ローカルホストの場合のリダイレクト先を設定（例: localhost:3000 へのリダイレクト）
+        const redirectUrl = 'http://localhost:3000';
+        return res.redirect(redirectUrl);
+      }
+
+      // サブドメインがある場合は、ホスト名に基づいてリダイレクト先を生成
+      const redirectUrl = `https://${host}`;
+      return res.redirect(redirectUrl);
     });
   },
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2320,6 +2320,11 @@ csstype@^3.0.2, csstype@^3.1.3:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
+date-fns@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.6.0.tgz#f20ca4fe94f8b754951b24240676e8618c0206bf"
+  integrity sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==
+
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
## 対象の Issue

Fix: https://github.com/itizawa/wisblog/issues/74

## 変更点(UI の変更があればスクリーンショットも)

![localhost_3000_dashboards_blogs(PC)](https://github.com/user-attachments/assets/d3f2e377-45eb-4063-a05b-18e9ba53aa46)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Users can now view their own blogs in a dedicated dashboard section.
	- A new dashboard link has been added to the navigation menu for quick access.
	- Introduced a `BlogCard` component for displaying individual blog posts with enhanced formatting.

- **Bug Fixes**
	- Improved handling of date fields in blog data for better accuracy.

- **Documentation**
	- Updated package dependencies to include `date-fns` for date manipulation.

- **Chores**
	- Enhanced cookie security settings for session management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->