### PR TITLE
下書き状態の記事にアクセスできるようにした

### DIFF
--- a/apps/web/src/actions/article.ts
+++ b/apps/web/src/actions/article.ts
@@ -2,19 +2,7 @@
 
 import type { Article } from '@repo/types';
 import { trpcClient } from '~/libs/trpcClient/trpcClient';
-
-const transferToObject = (
-  article: Omit<Article, 'createdAt' | 'updatedAt'> & {
-    createdAt: string;
-    updatedAt: string;
-  },
-) => {
-  return {
-    ...article,
-    createdAt: new Date(article.createdAt),
-    updatedAt: new Date(article.updatedAt),
-  };
-};
+import { convertStringsToDates } from '~/utils/convertStringsToDates';
 
 export const getArticle = async ({
   id,
@@ -25,7 +13,7 @@ export const getArticle = async ({
     id,
   });
 
-  return article ? transferToObject(article) : null;
+  return article ? convertStringsToDates<Article>(article) : null;
 };
 
 export const convertStatus = async ({

--- a/apps/web/src/app/[subDomain]/[articleId]/page.tsx
+++ b/apps/web/src/app/[subDomain]/[articleId]/page.tsx
@@ -1,7 +1,7 @@
-import { Stack } from '@mui/material';
+import { Alert, Stack } from '@mui/material';
 import { notFound } from 'next/navigation';
+import { getArticle } from '~/actions/article';
 import { getBlogsBySubDomain } from '~/actions/blog';
-import { getPublishArticle } from '~/actions/publishArticle';
 import { getCurrentUser } from '~/actions/user';
 import { ArticleBreadcrumbs } from '~/components/models/article/ArticleBreadcrumbs';
 import { ArticlePaper } from '~/components/models/article/ArticlePaper';
@@ -9,7 +9,7 @@ import { ArticlePaper } from '~/components/models/article/ArticlePaper';
 export default async function Page({ params }: { params: { subDomain: string; articleId: string } }) {
   const [blog, article, { currentUser }] = await Promise.all([
     getBlogsBySubDomain({ subDomain: params.subDomain }),
-    getPublishArticle({ id: params.articleId }),
+    getArticle({ id: params.articleId }),
     getCurrentUser(),
   ]);
 
@@ -20,6 +20,7 @@ export default async function Page({ params }: { params: { subDomain: string; ar
   return (
     <Stack maxWidth={900} mx='auto' py={4} px={2} gap={1}>
       <ArticleBreadcrumbs blogName={blog.name} blogSubDomain={blog.subDomain} articleTitle={article.title} />
+      {article.status === 'draft' && <Alert severity='warning'>この記事は下書き状態です</Alert>}
       <ArticlePaper key={article.id} currentUser={currentUser} article={article} blog={blog} />
     </Stack>
   );

--- a/apps/web/src/app/dashboards/blogs/[blogId]/articles/[articleId]/edit/page.tsx
+++ b/apps/web/src/app/dashboards/blogs/[blogId]/articles/[articleId]/edit/page.tsx
@@ -3,6 +3,9 @@ import { notFound } from 'next/navigation';
 import { getArticle } from '~/actions/article';
 import { getBlog } from '~/actions/blog';
 import { ArticleForm } from '~/components/models/article/ArticleForm';
+import { generateWisblogMetadata } from '~/libs/generateWisblogMetadata';
+
+export const metadata = generateWisblogMetadata({ title: '記事の編集' });
 
 export default async function Page({ params }: { params: { blogId: string; articleId: string } }) {
   const [blog, article] = await Promise.all([getBlog({ id: params.blogId }), getArticle({ id: params.articleId })]);

--- a/apps/web/src/app/dashboards/blogs/[blogId]/articles/page.tsx
+++ b/apps/web/src/app/dashboards/blogs/[blogId]/articles/page.tsx
@@ -10,6 +10,9 @@ import { ArticleSummaryPaperForAdmin } from '~/components/models/article/Article
 import { CreateNewArticleButton } from '~/components/models/article/CreateNewArticleButton';
 import { LoadingBox } from '~/components/uiParts/LoadingBox';
 import { WisblogTabs } from '~/components/uiParts/WisblogTabs';
+import { generateWisblogMetadata } from '~/libs/generateWisblogMetadata';
+
+export const metadata = generateWisblogMetadata({ title: '記事一覧' });
 
 export default async function Page({ params }: { params: { blogId: string } }) {
   const { currentUser } = await getCurrentUser();
@@ -21,7 +24,7 @@ export default async function Page({ params }: { params: { blogId: string } }) {
 
   return (
     <Stack maxWidth={600} mx='auto' py={4} gap={3} px={2}>
-      <Stack direction='row' justifyContent='space-between'>
+      <Stack direction='row' justifyContent='space-between' columnGap={2}>
         <Typography variant='h5'>{blog.name} の記事一覧</Typography>
         <CreateNewArticleButton blogId={blog.id} />
       </Stack>

--- a/apps/web/src/app/dashboards/blogs/[blogId]/articles/page.tsx
+++ b/apps/web/src/app/dashboards/blogs/[blogId]/articles/page.tsx
@@ -24,8 +24,9 @@ export default async function Page({ params }: { params: { blogId: string } }) {
 
   return (
     <Stack maxWidth={600} mx='auto' py={4} gap={3} px={2}>
+      <Typography variant='h4'>{blog.name}</Typography>
       <Stack direction='row' justifyContent='space-between' columnGap={2}>
-        <Typography variant='h5'>{blog.name} の記事一覧</Typography>
+        <Typography variant='h5'>記事一覧</Typography>
         <CreateNewArticleButton blogId={blog.id} />
       </Stack>
       <WisblogTabs

--- a/apps/web/src/app/dashboards/blogs/page.tsx
+++ b/apps/web/src/app/dashboards/blogs/page.tsx
@@ -1,7 +1,10 @@
 import { Box, Stack, Typography } from '@mui/material';
 import { getCurrentUser } from '~/actions/user';
 import { BlogCard } from '~/components/models/blog/BlogCard';
+import { generateWisblogMetadata } from '~/libs/generateWisblogMetadata';
 import { getBlogsByOwnerId } from '../../../actions/blog';
+
+export const metadata = generateWisblogMetadata({ title: 'ブログ一覧' });
 
 export default async function Page() {
   const { currentUser } = await getCurrentUser();

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,8 +3,10 @@ import { getCurrentUser } from '~/actions/user';
 import { Navbar } from '~/components/layout/Navbar';
 import { SnackbarProvider } from '~/context/SnackbarProvider';
 import { ThemeProvider } from '~/context/ThemeProvider';
+import { generateWisblogMetadata } from '~/libs/generateWisblogMetadata';
 
 export const dynamic = 'force-dynamic';
+export const metadata = generateWisblogMetadata({ title: 'Wisblog' });
 
 export default async function RootLayout({
   children,

--- a/apps/web/src/components/models/article/AccessArticlePageIcon/AccessArticlePageIcon.tsx
+++ b/apps/web/src/components/models/article/AccessArticlePageIcon/AccessArticlePageIcon.tsx
@@ -1,0 +1,29 @@
+import { Preview } from '@mui/icons-material';
+import { Link } from '@mui/material';
+import type { FC } from 'react';
+import urlJoin from 'url-join';
+import { WisblogTooltip } from '~/components/uiParts/WisblogTooltip';
+import { appUrls } from '~/constants/appUrls';
+import { generateSubDomainUrl } from '~/utils/generateSubDomainUrl';
+
+type Props = {
+  subDomain: string;
+  articleId: string;
+};
+
+export const AccessArticlePageIcon: FC<Props> = ({ subDomain, articleId }) => {
+  return (
+    <Link
+      underline='hover'
+      color='inherit'
+      target='_blank'
+      rel='noopener noreferrer'
+      style={{ height: 24 }}
+      href={urlJoin(generateSubDomainUrl(subDomain), appUrls.blogs.article(articleId))}
+    >
+      <WisblogTooltip title='記事にアクセスする'>
+        <Preview />
+      </WisblogTooltip>
+    </Link>
+  );
+};

--- a/apps/web/src/components/models/article/AccessArticlePageIcon/index.ts
+++ b/apps/web/src/components/models/article/AccessArticlePageIcon/index.ts
@@ -1,0 +1,1 @@
+export { AccessArticlePageIcon } from './AccessArticlePageIcon';

--- a/apps/web/src/components/models/article/ArticleBreadcrumbs/ArticleBreadcrumbs.tsx
+++ b/apps/web/src/components/models/article/ArticleBreadcrumbs/ArticleBreadcrumbs.tsx
@@ -17,7 +17,7 @@ export const ArticleBreadcrumbs: FC<Props> = ({ blogSubDomain, blogName, article
       <Link underline='hover' color='inherit' href={generateSubDomainUrl(blogSubDomain)}>
         {blogName}
       </Link>
-      <Typography sx={{ color: 'text.primary' }}>{articleTitle}</Typography>
+      <Typography sx={{ color: 'text.primary' }}>{articleTitle === '' ? '無題' : articleTitle}</Typography>
     </Breadcrumbs>
   );
 };

--- a/apps/web/src/components/models/article/ArticleForm/ArticleForm.tsx
+++ b/apps/web/src/components/models/article/ArticleForm/ArticleForm.tsx
@@ -3,23 +3,19 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Public, PublicOff } from '@mui/icons-material';
 import { LoadingButton } from '@mui/lab';
-import { Box, Link, Paper, Stack, TextField, Typography, useTheme } from '@mui/material';
+import { Box, Paper, Stack, TextField, Typography, useTheme } from '@mui/material';
 import { type Article, ArticleSchema } from '@repo/types';
 import debounce from 'lodash/debounce';
 import { useSnackbar } from 'notistack';
 import type { FC } from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import urlJoin from 'url-join';
 import type { z } from 'zod';
-
 import { convertStatus } from '~/actions/article';
 import { updateDraftArticle } from '~/actions/draftArticle';
 import { updatePublishArticle } from '~/actions/publishArticle';
 import { Editor } from '~/components/uiParts/Editor';
-import { appUrls } from '~/constants/appUrls';
 import { mutateArticle, useArticle } from '~/hooks/article/useArticle/useArticle';
-
-import { generateSubDomainUrl } from '~/utils/generateSubDomainUrl';
+import { AccessArticlePageIcon } from '../AccessArticlePageIcon';
 
 const inputSchema = ArticleSchema;
 type InputState = z.infer<typeof inputSchema>;
@@ -184,16 +180,12 @@ export const ArticleFormCore: FC<Props> = ({ subDomain, existingArticle }) => {
             top: 24,
           }}
         >
-          <Typography variant='body1'>記事設定</Typography>
-          <Link
-            underline='hover'
-            color='inherit'
-            target='_blank'
-            rel='noopener noreferrer'
-            href={urlJoin(generateSubDomainUrl(subDomain), appUrls.blogs.article(existingArticle.id))}
-          >
-            <Typography variant='body2'>実際の画面に飛ぶ</Typography>
-          </Link>
+          <Stack direction='row' alignItems='center' gap={2}>
+            <Typography variant='body1' sx={{ fontWeight: 700 }}>
+              記事設定
+            </Typography>
+            <AccessArticlePageIcon subDomain={subDomain} articleId={existingArticle.id} />
+          </Stack>
           <Stack gap='16px'>
             <LoadingButton
               type='submit'

--- a/apps/web/src/components/models/article/ArticlePaper/ArticlePaper.tsx
+++ b/apps/web/src/components/models/article/ArticlePaper/ArticlePaper.tsx
@@ -4,7 +4,7 @@ import './styles.scss';
 import { MoreVert } from '@mui/icons-material';
 import { Box, IconButton, Link, Paper, Typography, useTheme } from '@mui/material';
 import { can } from '@repo/access-control';
-import type { Article, Blog, User } from '@repo/types';
+import type { Blog, DraftArticle, PublishArticle, User } from '@repo/types';
 import { format } from 'date-fns';
 import parse from 'html-react-parser';
 import { useRouter } from 'next/navigation';
@@ -18,7 +18,7 @@ import { generateSubDomainUrl } from '~/utils/generateSubDomainUrl';
 type Props = {
   currentUser: User | null;
   blog: Blog;
-  article: Article;
+  article: DraftArticle | PublishArticle;
 };
 
 export const ArticlePaper: FC<Props> = ({ currentUser, blog, article }) => {

--- a/apps/web/src/components/models/article/ArticlePaper/ArticlePaper.tsx
+++ b/apps/web/src/components/models/article/ArticlePaper/ArticlePaper.tsx
@@ -4,7 +4,7 @@ import './styles.scss';
 import { MoreVert } from '@mui/icons-material';
 import { Box, IconButton, Link, Paper, Typography, useTheme } from '@mui/material';
 import { can } from '@repo/access-control';
-import type { Blog, PublishArticle, User } from '@repo/types';
+import type { Article, Blog, User } from '@repo/types';
 import { format } from 'date-fns';
 import parse from 'html-react-parser';
 import { useRouter } from 'next/navigation';
@@ -18,7 +18,7 @@ import { generateSubDomainUrl } from '~/utils/generateSubDomainUrl';
 type Props = {
   currentUser: User | null;
   blog: Blog;
-  article: PublishArticle;
+  article: Article;
 };
 
 export const ArticlePaper: FC<Props> = ({ currentUser, blog, article }) => {
@@ -29,7 +29,7 @@ export const ArticlePaper: FC<Props> = ({ currentUser, blog, article }) => {
       <Box display='flex' alignItems='center' justifyContent='space-between'>
         <Link href={urlJoin(generateSubDomainUrl(blog.subDomain), article.id)} underline='hover' color='inherit'>
           <Typography variant='h5' component='div'>
-            {article.title}
+            {article.title === '' ? '無題' : article.title}
           </Typography>
         </Link>
         {can({ type: 'publish_article', action: 'update', user: currentUser, blog, publishArticle: article }) && (

--- a/apps/web/src/components/models/article/ArticleSummaryPaperForAdmin/ArticleSummaryPaperForAdmin.tsx
+++ b/apps/web/src/components/models/article/ArticleSummaryPaperForAdmin/ArticleSummaryPaperForAdmin.tsx
@@ -7,6 +7,7 @@ import type { FC } from 'react';
 import urlJoin from 'url-join';
 import { appUrls } from '~/constants/appUrls';
 import { generateMainUrl } from '~/utils/generateMainUrl';
+import { AccessArticlePageIcon } from '../AccessArticlePageIcon';
 
 type Props = {
   blog: Blog;
@@ -26,6 +27,7 @@ export const ArticleSummaryPaperForAdmin: FC<Props> = ({ blog, article }) => {
             {article.title === '' ? '無題' : article.title}
           </Typography>
         </Link>
+        <AccessArticlePageIcon subDomain={blog.subDomain} articleId={article.id} />
       </Box>
       <Box sx={{ display: 'flex', flexDirection: 'column', rowGap: 3 }}>
         <Box display='flex' columnGap={2} sx={{ pb: 1 }}>

--- a/apps/web/src/components/uiParts/Editor/Editor.tsx
+++ b/apps/web/src/components/uiParts/Editor/Editor.tsx
@@ -46,7 +46,6 @@ export const Editor: FC<Props> = ({ body, placeholder, onChange }) => {
   const editor = useEditor({
     extensions,
     content: body,
-    autofocus: 'end',
     onUpdate: ({ editor }) => {
       onChange(editor.getHTML());
     },

--- a/apps/web/src/components/uiParts/WisblogTooltip/WisblogTooltip.tsx
+++ b/apps/web/src/components/uiParts/WisblogTooltip/WisblogTooltip.tsx
@@ -1,0 +1,15 @@
+import { Tooltip } from '@mui/material';
+import type { FC, ReactElement } from 'react';
+
+type Props = {
+  title: string;
+  children: ReactElement;
+};
+
+export const WisblogTooltip: FC<Props> = ({ title, children }) => {
+  return (
+    <Tooltip title={title} placement='top' arrow>
+      {children}
+    </Tooltip>
+  );
+};

--- a/apps/web/src/components/uiParts/WisblogTooltip/index.ts
+++ b/apps/web/src/components/uiParts/WisblogTooltip/index.ts
@@ -1,0 +1,1 @@
+export { WisblogTooltip } from './WisblogTooltip';

--- a/apps/web/src/libs/generateWisblogMetadata/generateWisblogMetadata.ts
+++ b/apps/web/src/libs/generateWisblogMetadata/generateWisblogMetadata.ts
@@ -1,0 +1,41 @@
+import type { Metadata } from 'next';
+
+const DEFAULT_TITLE = 'Wisblog';
+const DEFAULT_DESCRIPTION = 'シンプルで賢いブログサービス';
+const DEFAULT_URL = 'https://wiscro.app/';
+
+type Args = {
+  title?: string;
+  description?: string;
+  url?: string;
+  images?: string[];
+};
+
+export const generateWisblogMetadata = ({
+  title = DEFAULT_TITLE,
+  description = DEFAULT_DESCRIPTION,
+  url = DEFAULT_URL,
+  images,
+}: Args): Metadata => {
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: 'Wisblog',
+      locale: 'ja_JP',
+      type: 'website',
+      images,
+    },
+    twitter: {
+      card: 'summary',
+      title,
+      description,
+      site: '@',
+      creator: '@',
+    },
+    metadataBase: new URL('https://wiscro.app/'),
+  };
+};

--- a/apps/web/src/libs/generateWisblogMetadata/index.ts
+++ b/apps/web/src/libs/generateWisblogMetadata/index.ts
@@ -1,0 +1,1 @@
+export { generateWisblogMetadata } from './generateWisblogMetadata';

--- a/packages/api/prisma/migrations/20241013140309_cteate_status/migration.sql
+++ b/packages/api/prisma/migrations/20241013140309_cteate_status/migration.sql
@@ -1,0 +1,2 @@
+-- CreateEnum
+CREATE TYPE "statuses" AS ENUM ('publish', 'draft');


### PR DESCRIPTION


## 変更点(UI の変更があればスクリーンショットも)

-
<img width="984" alt="スクリーンショット 2024-10-13 22 29 49" src="https://github.com/user-attachments/assets/cc8f824e-dded-407c-9fa9-8556ef6d7bcd">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced `AccessArticlePageIcon` and `WisblogTooltip` components for enhanced user interaction.
	- Added metadata generation for Wisblog pages, improving SEO and page information.
	- Alerts now display when an article's status is 'draft', providing better user feedback.
	- Enhanced article editing and listing pages with new metadata exports.
	- Article retrieval logic updated to improve user experience.

- **Bug Fixes**
	- Updated article title rendering to default to '無題' when no title is provided, enhancing clarity.

- **Refactor**
	- Streamlined article retrieval logic and removed obsolete functions for improved performance.

- **Style**
	- Enhanced visual hierarchy in article listing pages with new layout components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->